### PR TITLE
bump semver range version, fix ambiguity with throw

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -32,15 +32,15 @@ let
 
   semver-range = with haskellPackages; mkDerivation rec {
     pname = "semver-range";
-    version = "0.2.0";
+    version = "0.2.2";
     src = pkgs.fetchurl {
       url = "https://api.github.com/repos/adnelson/semver-range/tarball/${version}";
       name = "semver-range-${version}.tar.gz";
-      sha256 = "1h40ww6m8lx8nx73550dd0r4iig4nrlgsmbn6zc174kc6lsd3m3b";
+      sha256 = "1szawsh3vp16m7xfx3cm0c6026dgbxwm32r78pkw0v15aiq5fgxk";
     };
     isLibrary = true;
-    buildDepends = [ base classy-prelude parsec text cabal-install
-                     unordered-containers ];
+    buildDepends = [ base classy-prelude parsec text cabal-install QuickCheck
+                     unordered-containers hspec ];
     description = "An implementation of semver and semantic version ranges";
     license = pkgs.lib.licenses.mit;
   };

--- a/src/NixFromNpm/Common.hs
+++ b/src/NixFromNpm/Common.hs
@@ -38,14 +38,15 @@ module NixFromNpm.Common (
     uriToText, uriToString, putStrsLn, putStrs, dropSuffix, maybeIf, failC,
     errorC, joinBy, mapJoinBy, getEnv, modifyMap, pshow, unsafeParseURI,
     parseURIText, withColor, withUL, warn, warns, assert, fatal, fatalC,
-    partitionEither
+    partitionEither, throw
   ) where
 
 import ClassyPrelude hiding (assert, asList, find, FilePath, bracket,
                              maximum, maximumBy, (</>), (<>),
                              minimum, try, stripPrefix, ioError,
-                             mapM_, sequence_, foldM, forM_,
+                             mapM_, sequence_, foldM, forM_, throw, throwIO,
                              filterM, replicateM, writeFile, readFile)
+import Control.Exception (throw)
 import qualified Prelude as P
 import Control.Monad.RWS.Strict hiding (Any)
 import Control.Monad (when)
@@ -57,7 +58,7 @@ import Control.Monad.State.Strict (MonadState, StateT, State, get, gets,
                                    runStateT, execState, execStateT,
                                    evalState, evalStateT)
 import Control.Monad.Except (ExceptT, MonadError(..), throwError, runExceptT)
-import Control.Exception.Lifted hiding (assert)
+import Control.Exception.Lifted () -- hiding (assert, )
 import Control.Monad.Identity (Identity(..))
 import Control.Monad.Trans.Control
 import Control.Applicative hiding (empty, optional)

--- a/src/NixFromNpm/Conversion/ToNix.hs
+++ b/src/NixFromNpm/Conversion/ToNix.hs
@@ -59,8 +59,8 @@ fixName = replace "." "-"
 -- Example: "foo.bar" and 1.2.3-baz turns into "foo-bar_1-2-3-baz"
 -- Example: "@foo/bar" and 1.2.3 turns into "namespaces.foo.bar_1-2-3"
 toDepExpr :: PackageName -> SemVer -> NExpr
-toDepExpr (PackageName name mNamespace) (SemVer a b c tags) = do
-  let suffix = pack $ intercalate "-" $ (map show [a, b, c]) <> map unpack tags
+toDepExpr (PackageName name mNamespace) (SemVer a b c (PrereleaseTags tags) _) = do
+  let suffix = pack $ intercalate "-" $ (map show [a, b, c]) <> map show tags
       ident = fixName name <> "_" <> suffix
   case mNamespace of
     Nothing -> mkSym ident
@@ -71,8 +71,8 @@ toDepExpr (PackageName name mNamespace) (SemVer a b c tags) = do
 -- be used in a binding. This is very similar to @toDepExpr@, but it returns
 -- something to be used in a binding rather than an expression.
 toSelector :: PackageName -> SemVer -> NAttrPath NExpr
-toSelector (PackageName name mNamespace) (SemVer a b c tags) = do
-  let suffix = pack $ intercalate "-" $ (map show [a, b, c]) <> map unpack tags
+toSelector (PackageName name mNamespace) (SemVer a b c (PrereleaseTags tags) _) = do
+  let suffix = pack $ intercalate "-" $ (map show [a, b, c]) <> map show tags
       ident = fixName name <> "_" <> suffix
   StaticKey <$> case mNamespace of
     Nothing -> [ident]

--- a/src/NixFromNpm/Npm/Version/Parser.hs
+++ b/src/NixFromNpm/Npm/Version/Parser.hs
@@ -11,7 +11,7 @@ import qualified Text.Parsec as Parsec
 import Data.Aeson
 import qualified Data.Aeson.Types as DAT
 
-import Data.SemVer
+import Data.SemVer (pSemVerRange, anyVersion)
 import NixFromNpm.Npm.Version
 import NixFromNpm.Git.Types hiding (Tag)
 

--- a/src/NixFromNpm/NpmLookup.hs
+++ b/src/NixFromNpm/NpmLookup.hs
@@ -195,7 +195,7 @@ getHttpWith timeout retries headers uri = loop retries where
     (code, status, content) <- curlGetBS (uriToString uri) opts
     case code of
       CurlOK -> return content
-      code | retries <= 0 -> throwIO $ toErr status code
+      code | retries <= 0 -> throw $ toErr status code
            | otherwise -> do
                putStrsLn ["Request failed. ", pshow retries, " retries left."]
                loop (retries - 1)
@@ -261,13 +261,13 @@ _getPackageInfo pkgName registryUri = do
   jsonStr <- getHttp (registryUri // route) authHeader
              `catches` [
                Handler (\case
-                HttpErrorWithCode 404 -> throwIO $ NoMatchingPackage pkgName
-                err -> throwIO err)
+                HttpErrorWithCode 404 -> throw $ NoMatchingPackage pkgName
+                err -> throw err)
                ]
   case eitherDecode jsonStr of
       Left err -> do
         let text = decodeUtf8 $ BL8.toStrict jsonStr
-        throwIO $ InvalidPackageJson text err
+        throw $ InvalidPackageJson text err
       Right info -> do
         return info
 
@@ -279,14 +279,14 @@ getPackageInfo name = do
     Just info -> do
       return info
     Nothing -> do
-      let tryToFetch [] = throwIO $ NoMatchingPackage name
+      let tryToFetch [] = throw $ NoMatchingPackage name
           tryToFetch (registry:registries) = do
             putStrsLn ["Trying to fetch from ", uriToText registry]
             _getPackageInfo name registry
             `catch` \case
               NoMatchingPackage _ -> tryToFetch registries
               NoMatchingVersion _ -> tryToFetch registries
-              err -> throwIO err
+              err -> throw err
       info <- tryToFetch =<< asks nfsRegistries
       storePackageInfo name info
       return info
@@ -377,7 +377,7 @@ extractPkgJson path = do
   putStrsLn ["Reading information from ", pathToText path]
   pkJson <- liftIO $ B.readFile (encodeString path)
   case eitherDecode $ BL8.fromStrict pkJson of
-    Left err -> throwIO $ InvalidPackageJson (decodeUtf8 pkJson) err
+    Left err -> throw $ InvalidPackageJson (decodeUtf8 pkJson) err
     Right info -> return info
 
 -- | Fetch a package over HTTP. Return the version of the fetched package,
@@ -408,7 +408,7 @@ githubCurl uri = do
   putStrsLn ["GET ", uriToText uri]
   jsonStr <- getHttp uri headers
   case eitherDecode jsonStr of
-    Left err -> throwIO $ InvalidJsonFromGithub (pshow err)
+    Left err -> throw $ InvalidJsonFromGithub (pshow err)
     Right info -> return info
 
 makeGithubURI :: Name -> Name -> URI
@@ -445,21 +445,21 @@ gitRefToSha owner repo ref = case ref of
       tagMap <- tagListToMap <$> githubCurl (uri // "tags")
       case H.lookup tag tagMap of
         Just sha -> return sha
-        Nothing -> throwIO (InvalidGitRef ref)
+        Nothing -> throw (InvalidGitRef ref)
     fromCommit ref = do
       cSha <$> githubCurl (uri // "commits" // ref)
     catch404 action1 action2 = action1 `catch` \case
       HttpErrorWithCode 404 -> action2
-      err -> throwIO err
+      err -> throw err
     tryAll txt =
       fromBranch txt `catch404`
         fromTag txt `catch404`
           fromCommit txt `catch404`
-            throwIO (InvalidGitRef ref)
+            throw (InvalidGitRef ref)
 
 -- | Fetches an arbitrary git repo from a uri.
 fetchArbitraryGit :: URI -> NpmFetcher SemVer
-fetchArbitraryGit uri = throwIO $
+fetchArbitraryGit uri = throw $
   NotYetImplemented $
     concat ["nixfromnpm can't fetch arbitrary git repos yet (",
             uriToString uri, ")"]
@@ -507,7 +507,7 @@ fromGithubUri uri = resolveUri `catch` \(e::GithubError) -> fetchHttp uri where
         let ref' = tarballNameToRef ref
         hash <- gitRefToSha owner repo ref'
         return (owner, repo, hash)
-      _ -> throwIO $ InvalidGithubUri uri
+      _ -> throw $ InvalidGithubUri uri
     fetchHttp $ makeGithubTarballURI owner repo sha
 
 -- | Look up a name and version range to see if we have recorded this as being
@@ -818,7 +818,7 @@ _resolveDep name range = do
   current <- gets currentlyResolving
   -- Choose the entry with the highest version that matches the range.
   case filter (matches range) $ H.keys (piVersions pInfo) of
-    [] -> throwIO $ NoMatchingVersion $ SemVerRange range
+    [] -> throw $ NoMatchingVersion $ SemVerRange range
     matches -> do
       let versionInfo = piVersions pInfo H.! maximum matches
       versionInfoToSemVer versionInfo
@@ -830,7 +830,7 @@ resolveByTag :: Name -- ^ Tag name.
 resolveByTag tag pkgName = do
   pInfo <- getPackageInfo pkgName
   case H.lookup tag $ piTags pInfo of
-    Nothing -> throwIO $ NoSuchTag tag
+    Nothing -> throw $ NoSuchTag tag
     Just version -> case H.lookup version $ piVersions pInfo of
       Nothing -> errorC ["Tag ", tag, " points to version ",
                          pshow version, ", but no such version of ",

--- a/src/NixFromNpm/Options.hs
+++ b/src/NixFromNpm/Options.hs
@@ -11,7 +11,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.HashMap.Strict as H
 
-import Data.SemVer
+import Data.SemVer (anyVersion)
 import Options.Applicative
 
 import NixFromNpm.NpmLookup (getNpmTokens, parseNpmTokens)


### PR DESCRIPTION
fixes #68

fixes part of #62, namely the fix to semver-range bug which prevented some version ranges from matching correctly. But circular dependencies issues remain as todo.