### PR TITLE
Relax upper bound constraint on base

### DIFF
--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -47,7 +47,7 @@ library
                      , TypeFamilies
                      , TypeSynonymInstances
                      , ViewPatterns
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && < 5.0
                      , classy-prelude
                      , text
                      , bytestring
@@ -93,7 +93,7 @@ executable nixfromnpm
                      , TypeFamilies
                      , TypeSynonymInstances
                      , ViewPatterns
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && < 5.0
                      , classy-prelude
                      , text
                      , bytestring
@@ -138,7 +138,7 @@ test-suite unit-tests
                      , TypeFamilies
                      , TypeSynonymInstances
                      , ViewPatterns
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && < 5.0
                      , classy-prelude
                      , text
                      , bytestring


### PR DESCRIPTION
... so that nixfromnpm can be built with GHC 8.x