### PR TITLE
Fixes #78, fully initialize nodeLib

### DIFF
--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -66,7 +66,6 @@ library
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
-                     , turtle
                      , temporary
                      , SHA
                      , monad-control
@@ -113,7 +112,6 @@ executable nixfromnpm
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
-                     , turtle
                      , temporary
                      , SHA
                      , monad-control
@@ -159,7 +157,6 @@ test-suite unit-tests
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
-                     , turtle
                      , temporary
                      , SHA
                      , monad-control

--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -66,6 +66,7 @@ library
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
+                     , turtle
                      , temporary
                      , SHA
                      , monad-control
@@ -112,6 +113,7 @@ executable nixfromnpm
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
+                     , turtle
                      , temporary
                      , SHA
                      , monad-control
@@ -157,6 +159,7 @@ test-suite unit-tests
                      , hnix >=0.2.3
                      , optparse-applicative
                      , curl
+                     , turtle
                      , temporary
                      , SHA
                      , monad-control

--- a/src/NixFromNpm/Conversion/ToDisk.hs
+++ b/src/NixFromNpm/Conversion/ToDisk.hs
@@ -180,7 +180,7 @@ initializeOutput = do
       -- contain nix libraries.
       nixlibs <- getDataFileName "nix-libs"
 
-      let inputNodeLib  = nixlibs    </> "nodeLib"
+      let inputNodeLib = nixlibs </> "nodeLib"
       let outputNodeLib = outputPath </> "nodeLib"
 
       putStrsLn ["Generating node libraries in ", pathToText outputPath]
@@ -189,9 +189,8 @@ initializeOutput = do
         rm_rf outputNodeLib
         cp_r inputNodeLib outputNodeLib
 
-        let tools     = outputNodeLib </> "tools"
-        let toolsText = either id id (toText tools)
-        run_ "chmod" [ "-R", "+x", toolsText ]
+        let tools = outputNodeLib </> "tools"
+        run_ "chmod" [ "-R", "+x", (pathToText tools) ]
 
     extName:_ -> do -- Then we are extending things.
       unlessExists defaultNixPath $ do

--- a/src/NixFromNpm/Conversion/ToDisk.hs
+++ b/src/NixFromNpm/Conversion/ToDisk.hs
@@ -14,9 +14,10 @@ import qualified Data.HashSet as HS
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
+import Data.Either (either)
 import qualified Data.Text as T
 import Text.Printf (printf)
-import Shelly (shelly, cp_r, rm_rf)
+import Shelly (shelly, cp_r, rm_rf, run_)
 import System.Exit
 
 import Data.SemVer
@@ -187,6 +188,10 @@ initializeOutput = do
       shelly $ do
         rm_rf outputNodeLib
         cp_r inputNodeLib outputNodeLib
+
+        let tools     = outputNodeLib </> "tools"
+        let toolsText = either id id (toText tools)
+        run_ "chmod" [ "-R", "+x", toolsText ]
 
     extName:_ -> do -- Then we are extending things.
       unlessExists defaultNixPath $ do

--- a/src/NixFromNpm/Conversion/ToDisk.hs
+++ b/src/NixFromNpm/Conversion/ToDisk.hs
@@ -18,6 +18,7 @@ import qualified Data.Text as T
 import Text.Printf (printf)
 import Shelly (shelly, cp_r)
 import System.Exit
+import qualified Turtle
 
 import Data.SemVer
 
@@ -179,11 +180,9 @@ initializeOutput = do
       -- Get the path to the files bundled with nixfromnpm which contain
       -- nix libraries.
       nodeLibPath <- (</> "nodeLib") <$> getDataFileName "nix-libs"
-      -- Copy each of these into the target (unless they exist).
-      forItemsInDir_ nodeLibPath $ \path -> do
-        whenM (isFile path) $ do
-          unlessExists (outputPath </> "nodeLib" </> filename path) $
-            copyFile path (outputPath </> "nodeLib" </> filename path)
+
+      Turtle.cptree nodeLibPath (outputPath </> "nodeLib")
+
     extName:_ -> do -- Then we are extending things.
       unlessExists defaultNixPath $ do
         writeNix defaultNixPath $

--- a/src/NixFromNpm/Conversion/ToDisk.hs
+++ b/src/NixFromNpm/Conversion/ToDisk.hs
@@ -174,12 +174,15 @@ initializeOutput = do
     [] -> do -- Then we are creating a new root.
       unlessExists defaultNixPath $
         writeNix (outputPath </> "default.nix") $ rootDefaultNix npm3
+
+      -- Get the path to the files bundled with nixfromnpm which
+      -- contain nix libraries.
+      nixlibs <- getDataFileName "nix-libs"
+
+      let inputNodeLib  = nixlibs    </> "nodeLib"
       let outputNodeLib = outputPath </> "nodeLib"
 
       putStrsLn ["Generating node libraries in ", pathToText outputPath]
-
-      nixlibs <- getDataFileName "nix-libs"
-      let inputNodeLib = nixlibs </> "nodeLib"
 
       shelly $ do
         rm_rf outputNodeLib

--- a/src/NixFromNpm/Options.hs
+++ b/src/NixFromNpm/Options.hs
@@ -205,7 +205,7 @@ validateOptions opts@(RawOptions{..}) = do
   tokensCommandLine <- parseNpmTokens roNpmTokens
   npmTokensEnv <- getNpmTokens
   return $ NixFromNpmOptions {
-    nfnoOutputPath = outputPath,
+    nfnoOutputPath = collapse outputPath,
     nfnoExtendPaths = extendPaths,
     nfnoGithubToken = roGithubToken <|> githubTokenEnv,
     nfnoNpmTokens = tokensCommandLine <> npmTokensEnv,


### PR DESCRIPTION
... to include the tools sub-directory.

This change adds the `Turtle` library, providing the useful `cptree` function.

Note that `Turtle.cptree` clobbers so this does not preserve the original behavior of _not_ overwriting existing files within the generated `nodeLib` directory. My rationale as to why this is okay is as follows: (A) initialization occurs only once when the tool is run so it isn't expensive to copy the whole tree, (B) because it is generated there is no concern of overwriting manual modifications since users shouldn't manually modify generated code (they should instead override), and (C) rewriting the `nodeLib` on initialization ensures newer `nodeLib` Nix expressions are written if a new version of the utility is being executed.