### PR TITLE
Fixes #82; make overrideNodePackage more flexible

### DIFF
--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -593,10 +593,13 @@ let
         env = buildNodePackage (args // {includeDevDependencies = true;});
 
         # An 'overrideNodePackage' attribute, which will call
-        # `buildNodePackage` with the given arguments overridden.
+        # `buildNodePackage` with new arguments produced by the given
+        # arg-override function. The function consumes the original
+        # argument set.
+        #
         # We don't use the name `override` because this will get stomped on
         # if the derivation is the result of a `callPackage` application.
-        overrideNodePackage = newArgs: buildNodePackage (args // newArgs);
+        overrideNodePackage = newArgsFun: buildNodePackage (args // (newArgsFun args));
       });
     } // {
       name = if namePrefix == null then throw "Name prefix is null"

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -597,9 +597,19 @@ let
         # arg-override function. The function consumes the original
         # argument set.
         #
+        # N.B: the legacy behavior of accepting a set is preserved but
+        # the preferred usage-pattern is to supply a function that
+        # discards its argument; e.g:
+        #
+        # overrideNodePackage (_: { ... })
+        #
         # We don't use the name `override` because this will get stomped on
         # if the derivation is the result of a `callPackage` application.
-        overrideNodePackage = newArgsFun: buildNodePackage (args // (newArgsFun args));
+        overrideNodePackage = newArgs:
+          if builtins.isFunction newArgs
+          then buildNodePackage (args // (newArgs args))
+          else buildNodePackage (args // newArgs);
+
       });
     } // {
       name = if namePrefix == null then throw "Name prefix is null"

--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -157,7 +157,7 @@ rec {
         passthru.pkgName = name;
         passthru.basicName = "BROKEN";
         passthru.uniqueName = "BROKEN";
-        passthru.overrideNodePackage = (_: deriv);
+        passthru.overrideNodePackage = (_: (_: deriv));
         passthru.namespace = null;
         passthru.version = "BROKEN";
         passthru.override = _: deriv;


### PR DESCRIPTION
This change makes the `overrideNodePackage` function take a set-producing function instead of just a set with the original argument set threaded into the provided function.

The motivation is to make it easier to do overrides like the following:

```nix
nodePackages.chokidar.overrideNodePackage (oldArgs: {
  deps = (oldArgs.deps or []) ++ [ nodePackages.newdep ];
});
```