### PR TITLE
Fix data-files references

### DIFF
--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -21,8 +21,7 @@ data-files:   nix-libs/nodeLib/buildNodePackage.nix
             , nix-libs/nodeLib/circular_dependencies.md
             , nix-libs/nodeLib/default.nix
             , nix-libs/nodeLib/fetch.py
-            , nix-libs/nodeLib/fetchUrlWithHeaders.nix
-            , nix-libs/nodeLib/parseNpmAuthTokens.nix
+            , nix-libs/nodeLib/fetchUrlNamespaced.nix
             , nix-libs/nodeLib/tools/check-package-json
             , nix-libs/nodeLib/tools/install-binaries
             , nix-libs/nodeLib/tools/patch-dependencies


### PR DESCRIPTION
In ac44803 the following changes were made without reflecting them in the `data-files` directive in `nixfromnpm.cabal`:

- `fetchUrlWithHeaders.nix` renamed to `fetchUrlNamespaced.nix`; and,
- `parseNpmAuthTokens.nix` was removed