### PR TITLE
Fix broken newScope which provided the wrong `nodePackages`

### DIFF
--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -202,13 +202,13 @@ rec {
         inherit pkgs buildNodePackage brokenPackage extras;
       } // scope);
 
-      callPackage = pkgs.newScope (mkScope nodePackages);
+      callPackage = pkgs.newScope (mkScope { inherit nodePackages; });
 
       initialNodePackages = self: 
         let
           oldExtensions = joinSets (map (e: e.nodePackages) extensions);
           packageSet = pkgs.callPackage nodePackagesPath { 
-            callPackage = pkgs.newScope (mkScope self);
+            callPackage = pkgs.newScope (mkScope { nodePackages = self; });
           };
         in
           oldExtensions // packageSet;


### PR DESCRIPTION
In 76e82f1 we produced the wrong `callPackage` with `newScope` because the `nodePackages` and `self` (which is also a `nodePackages` set) attribute sets were provided at the top-level instead of within a `nodePackages` attribute.

This caused the `nodePackages` attribute that `callPackage` would fill-in when calling any package to _not_ have the default `nixpkgs` provided `nodePackages` instead of the `nodePackages` fix point we are inside of.

This change fixes that problem.