### PR TITLE
Make sure we include `namespaces` in the top-level scope

### DIFF
--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -202,13 +202,19 @@ rec {
         inherit pkgs buildNodePackage brokenPackage extras;
       } // scope);
 
-      callPackage = pkgs.newScope (mkScope { inherit nodePackages; });
+      callPackage = pkgs.newScope (mkScope {
+        inherit nodePackages;
+        inherit (nodePackages) namespaces;
+      });
 
       initialNodePackages = self: 
         let
           oldExtensions = joinSets (map (e: e.nodePackages) extensions);
           packageSet = pkgs.callPackage nodePackagesPath { 
-            callPackage = pkgs.newScope (mkScope { nodePackages = self; });
+            callPackage = pkgs.newScope (mkScope {
+              nodePackages = self;
+              inherit (self) namespaces;
+            });
           };
         in
           oldExtensions // packageSet;


### PR DESCRIPTION
In #95 I misunderstood why `namespaces` was being threaded through. This change fixes that oversight by explicitly adding the `namespaces` package to the top-level scope.