### PR TITLE
Initialize set of circular dependencies to be folded with those from self

### DIFF
--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -310,7 +310,7 @@ let
                         (attrValues package.circularDependencies);
         in
         # Combine the results into a single set.
-        foldl (a: b: a // b) {} closure;
+        foldl (a: b: a // b) self.circularDependencies closure;
 
     # Compute any cycles. Remove 'self' from the dependency closure.
     circularDepClosure = removeAttrs (circularClosure {} self) [self.name];


### PR DESCRIPTION
There may be a case in which `nixfromnpm` has detected a circular dependency for a package but `circularClosure` turns up empty handed. This likely means `nixfromnpm` is incorrectly detecting a circular dependency.

However, when this happens it means the package may not have a required dependency because `circularDepClosure` winds up with an empty set if `circularClosure` doesn't find its cycle.

Therefore, due to the way the circular dependency resolution works, it is technically safe to resolve a circular dependency that may not be circular by starting the fold function over the final closure with the the `circularDependencies` of `self`.