### PR TITLE
executable and tests depend on nixfromnpm library

### DIFF
--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -31,10 +31,6 @@ source-repository head
   type:     git
   location: git://github.com/adnelson/nixfromnpm.git
 
-flag development
-  default: False
-  description: Development mode
-
 library
   default-language: Haskell2010
   hs-source-dirs:      src

--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -31,21 +31,30 @@ source-repository head
   type:     git
   location: git://github.com/adnelson/nixfromnpm.git
 
+flag development
+  default: False
+  description: Development mode
+
 library
+  default-language: Haskell2010
   hs-source-dirs:      src
   exposed-modules:     NixFromNpm
-  other-extensions:    FlexibleContexts
-                     , FlexibleInstances
-                     , LambdaCase
+                     , NixFromNpm.Common
+                     , NixFromNpm.Options
+                     , NixFromNpm.Conversion.ToDisk
+                     , NixFromNpm.Git.Types
+                     , NixFromNpm.Npm.Version
+                     , NixFromNpm.Merge
+  other-modules:       Filesystem.Path.Wrappers
+                     , NixFromNpm.Parsers.Common
+                     , NixFromNpm.HttpTools
+                     , NixFromNpm.Conversion.ToNix
+                     , NixFromNpm.Npm.Resolve
+                     , NixFromNpm.Npm.Types
+                     , NixFromNpm.Npm.PackageMap
+                     , Paths_nixfromnpm
+  other-extensions:    LambdaCase
                      , NoImplicitPrelude
-                     , NoMonomorphismRestriction
-                     , OverloadedStrings
-                     , QuasiQuotes
-                     , RecordWildCards
-                     , ScopedTypeVariables
-                     , TypeFamilies
-                     , TypeSynonymInstances
-                     , ViewPatterns
   build-depends:       base >=4.8 && < 5.0
                      , classy-prelude
                      , text
@@ -72,101 +81,30 @@ library
                      , transformers
                      , unix
                      , ansi-terminal
-                     , semver-range >=0.2.4
+                     , semver-range >=0.2.7
                      , data-fix
                      , pcre-heavy
   default-language:    Haskell2010
 
 executable nixfromnpm
-  hs-source-dirs:      src
-  main-is:             Main.hs
-  other-extensions:    FlexibleContexts
-                     , FlexibleInstances
-                     , LambdaCase
-                     , NoImplicitPrelude
-                     , NoMonomorphismRestriction
-                     , OverloadedStrings
-                     , QuasiQuotes
-                     , RecordWildCards
-                     , ScopedTypeVariables
-                     , TypeFamilies
-                     , TypeSynonymInstances
-                     , ViewPatterns
+  default-language: Haskell2010
+  main-is:             src/Main.hs
   build-depends:       base >=4.8 && < 5.0
-                     , classy-prelude
-                     , text
-                     , bytestring
-                     , mtl
-                     , unordered-containers
-                     , containers
-                     , parsec
-                     , aeson
-                     , data-default
-                     , shelly
-                     , MissingH
-                     , text-render
-                     , system-filepath
-                     , network-uri
-                     , directory
-                     , hnix >=0.2.3
                      , optparse-applicative
-                     , curl
-                     , temporary
-                     , SHA
-                     , monad-control
-                     , lifted-base
-                     , transformers
-                     , unix
-                     , ansi-terminal
-                     , semver-range >=0.2.4
-                     , data-fix
-                     , pcre-heavy
+                     , nixfromnpm
+
 test-suite unit-tests
+  default-language: Haskell2010
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      src, tests
+  hs-source-dirs:      tests
   main-is:             Unit.hs
-  other-extensions:    FlexibleContexts
-                     , FlexibleInstances
-                     , LambdaCase
-                     , NoImplicitPrelude
-                     , NoMonomorphismRestriction
+  other-extensions:    NoImplicitPrelude
                      , OverloadedStrings
-                     , QuasiQuotes
-                     , RecordWildCards
-                     , ScopedTypeVariables
-                     , TypeFamilies
-                     , TypeSynonymInstances
-                     , ViewPatterns
   build-depends:       base >=4.8 && < 5.0
                      , classy-prelude
                      , text
-                     , bytestring
-                     , mtl
-                     , unordered-containers
-                     , containers
-                     , parsec
-                     , aeson
-                     , data-default
-                     , shelly
-                     , MissingH
-                     , text-render
-                     , system-filepath
-                     , network-uri
-                     , directory
-                     , hnix >=0.2.3
-                     , optparse-applicative
-                     , curl
-                     , temporary
-                     , SHA
-                     , monad-control
-                     , lifted-base
-                     , transformers
-                     , unix
-                     , ansi-terminal
-                     , semver-range >=0.2.4
-                     , data-fix
                      , hspec
                      , QuickCheck
-                     , pcre-heavy
+                     , nixfromnpm
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/src/NixFromNpm/Parsers/Common.hs
+++ b/src/NixFromNpm/Parsers/Common.hs
@@ -9,7 +9,7 @@ module NixFromNpm.Parsers.Common (
   ) where
 
 import qualified Prelude as P
-import Text.Parsec hiding (many, (<|>), spaces, parse, State, uncons)
+import Text.Parsec hiding (many, (<|>), spaces, parse, State, uncons, optional)
 import qualified Text.Parsec as Parsec
 
 import NixFromNpm.Common hiding (try)


### PR DESCRIPTION
fixes #105 and #80 