### PR TITLE
Filter all other dependency lists with skipOptionalDependencies

### DIFF
--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -22,12 +22,6 @@ let
                        attrValues concatStringsSep optionalString filter
                        optionalAttrs;
 
-  # Like `subtractLists` but tests each dependency element in the
-  # minuend list for membership in the subtrahend list using that
-  # dependency's `basicName`.
-  subtractDependencyLists = subtrahend:
-    filter (x: !(elem x.basicName subtrahend));
-
   # Join a list of strings with newlines, filtering out empty lines.
   joinLines = strings: concatStringsSep "\n" (filter (s: s != "") strings);
 
@@ -125,9 +119,7 @@ in
   # List of optional dependencies.
   optionalDependencies ? [],
 
-  # List of optional dependencies to skip. List of strings, where a string
-  # should contain the `name` of the derivation to skip (not a version or
-  # namespace).
+  # List of optional dependencies to skip.
   skipOptionalDependencies ? [],
 
   # List or set of development dependencies (or null). These will only be
@@ -233,7 +225,7 @@ let
   # We create a `self` object for self-referential expressions. It
   # bottoms out in a call to `mkDerivation` at the end.
   self = let
-    filterOptionalDeps = subtractDependencyLists skipOptionalDependencies;
+    filterOptionalDeps = subtractLists skipOptionalDependencies;
 
     # Set of normal dependencies.
     _dependencies =
@@ -249,12 +241,12 @@ let
 
     # Set of peer dependencies.
     _peerDependencies = 
-      toAttrSet (filterOptionalDeps peerDependencies);
+      toAttrSet peerDependencies;
 
     # Dev dependencies will only be included if requested.
     _devDependencies = 
       if !includeDevDependencies then {}
-      else toAttrSet (filterOptionalDeps devDependencies);
+      else toAttrSet devDependencies;
 
     # Dependencies we need to propagate, meaning they need to be
     # available to the package at runtime. We don't include the

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -22,6 +22,12 @@ let
                        attrValues concatStringsSep optionalString filter
                        optionalAttrs;
 
+  # Like `subtractLists` but tests each dependency element in the
+  # minuend list for membership in the subtrahend list using that
+  # dependency's `basicName`.
+  subtractDependencyLists = subtrahend:
+    filter (x: !(elem x.basicName subtrahend));
+
   # Join a list of strings with newlines, filtering out empty lines.
   joinLines = strings: concatStringsSep "\n" (filter (s: s != "") strings);
 
@@ -227,26 +233,36 @@ let
   # We create a `self` object for self-referential expressions. It
   # bottoms out in a call to `mkDerivation` at the end.
   self = let
+    filterOptionalDeps = subtractDependencyLists skipOptionalDependencies;
+
     # Set of normal dependencies.
-    _dependencies = toAttrSet deps;
+    _dependencies =
+      toAttrSet (filterOptionalDeps deps);
+
     # Set of circular dependencies.
-    _circularDependencies = toAttrSet circularDependencies;
+    _circularDependencies =
+      toAttrSet (filterOptionalDeps circularDependencies);
+
     # Set of optional dependencies.
-    _optionalDependencies = toAttrSet optionalDependencies;
+    _optionalDependencies =
+      toAttrSet (filterOptionalDeps optionalDependencies);
+
     # Set of peer dependencies.
-    _peerDependencies = toAttrSet peerDependencies;
+    _peerDependencies = 
+      toAttrSet (filterOptionalDeps peerDependencies);
 
     # Dev dependencies will only be included if requested.
-    _devDependencies = if !includeDevDependencies then {}
-                       else toAttrSet devDependencies;
+    _devDependencies = 
+      if !includeDevDependencies then {}
+      else toAttrSet (filterOptionalDeps devDependencies);
 
     # Dependencies we need to propagate, meaning they need to be
     # available to the package at runtime. We don't include the
     # circular dependencies here, even though they might be needed at
     # runtime, because we have a "special way" of building them.
-    runtimeDependencies = _dependencies //
-                             _optionalDependencies //
-                             _peerDependencies;
+    runtimeDependencies =  _dependencies
+      // _optionalDependencies
+      // _peerDependencies;
 
     # Names of packages to keep when cleaning up dev dependencies. We
     # put them in a dictionary for fast lookup, but the values are


### PR DESCRIPTION
Fixes #81

This was tested with the `chokidar` npm package which uses `fsevents`, a package that does not work on Linux and is an optional dependency.

Building `chokidar` fails with the following output (truncated for brevity):

```
...
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for fsevents@1.1.3: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm ERR! notsup Valid OS:    darwin
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   linux
npm ERR! notsup Actual Arch: x64
npm verb exit [ 1, true ]

npm ERR! A complete log of this run can be found in:
npm ERR!
/tmp/nix-build-fsevents-1.1.3-nodejs-8.9.4.drv-0/package/.npm/_logs/2018-02-18T22_06_04_943Z-debug.log
...
```

Overriding `chokidar` and adding `fsevents` to `skipOptionalDependencies` like so:

```
...
    (nodeLib.generatePackages {
      nodePackagesPath = ./nodePackages;
    }).override {
      overrides = nodePackagesNew: nodePackagesOld: {
        chokidar = nodePackagesOld.chokidar.overrideNodePackage (oldAttrs: {
          skipOptionalDependencies = (oldAttrs.skipOptionalDependencies or []) ++ [
            "fsevents"
          ];
        });
      };
    }
```

... allows the build of `chokidar` to succeed:

```
...
building
npm install --registry=http://notaregistry.078d3fd5b0-chokidar-2.0.2.com --fetch-retry-mintimeout=0 --fetch-retry-maxtimeout=10 --fetch-retries=0 --userconfig=/dev/null --nodedir=/nix/store/mlycgcw8j8bwqjsazp7hr1axiqnwhc4y-node-sources --production
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/masxiwniv9srsj7bs4p72m14gy2s1znk-chokidar-2.0.2-nodejs-8.9.4
patching script interpreter paths in /nix/store/masxiwniv9srsj7bs4p72m14gy2s1znk-chokidar-2.0.2-nodejs-8.9.4
checking for references to /tmp/nix-build-chokidar-2.0.2-nodejs-8.9.4.drv-0 in /nix/store/masxiwniv9srsj7bs4p72m14gy2s1znk-chokidar-2.0.2-nodejs-8.9.4...
/nix/store/masxiwniv9srsj7bs4p72m14gy2s1znk-chokidar-2.0.2-nodejs-8.9.4
```