### PR TITLE
validate package names

### DIFF
--- a/src/NixFromNpm/Npm/Types.hs
+++ b/src/NixFromNpm/Npm/Types.hs
@@ -11,8 +11,8 @@ import Data.Aeson
 import Data.Aeson.Types as Aeson (Parser, typeMismatch)
 import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
-
-import Data.SemVer
+import Data.SemVer (SemVer, SemVerRange)
+import Data.SemVer (parseSemVer, parseSemVerRange, anyVersion)
 
 import NixFromNpm.Common
 import NixFromNpm.Git.Types (getObject, GithubError)


### PR DESCRIPTION
Since we changed the syntax of specifying package names with a version range, I figured it would be helpful to specifically warn the user when they attempt to use that syntax. In the process, I added some regex-based validation of package names and some unit tests.