### PR TITLE
No npm install

### DIFF
--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -131,9 +131,6 @@ in
   # Bash command to run package tests.
   checkPhase ? defaultCheckPhase,
 
-  # Additional flags passed to npm install. A list of strings.
-  extraNpmFlags ? [],
-
   # Build inputs to propagate in addition to nodejs and non-dev dependencies.
   propagatedBuildInputs ? [],
 
@@ -242,27 +239,6 @@ let
 
     # Required dependencies are those that we haven't filtered yet.
     requiredDependencies = _devDependencies // runtimeDependencies;
-
-    # Flags that we will pass to `npm install`.
-    npmFlags = concatStringsSep " " ([
-      # We point the registry at something that doesn't exist. This will
-      # mean that NPM will fail if any of the dependencies aren't met, as it
-      # will attempt to hit this registry for the missing dependency.
-      "--registry=http://notaregistry.$UNIQNAME.com"
-      # These flags make failure fast, as otherwise NPM will spin for a while.
-      "--fetch-retry-mintimeout=0" "--fetch-retry-maxtimeout=10" "--fetch-retries=0"
-      # This will disable any user-level npm configuration.
-      "--userconfig=/dev/null"
-      # This flag is used for packages which link against the node headers.
-      "--nodedir=${nodejsSources}"
-      # This will tell npm not to run pre/post publish hooks
-      # "--ignore-scripts"
-      ] ++
-      # Use the --production flag if we're not running tests; this will make
-      # npm skip the dev dependencies.
-      (if !doCheck then ["--production"] else []) ++
-      # Add any extra headers that the user has passed in.
-      extraNpmFlags);
 
     patchPhase = joinLines [
       "runHook prePatch"
@@ -448,7 +424,7 @@ let
         fullName
         installPhase
         meta
-        npmFlags
+        nodejs
         patchPhase
         src;
 

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -429,8 +429,7 @@ let
 
       patchDependencies = builtins.toJSON patchDependencies;
 
-      # Informs lower scripts not to check dev dependencies
-      NO_DEV_DEPENDENCIES = devDependencies == null;
+      NO_DEV_DEPENDENCIES = !includeDevDependencies;
 
       # Tell mkDerivation to run `setVariables` prior to other phases.
       prePhases = ["setVariables"];

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -424,7 +424,6 @@ let
         fullName
         installPhase
         meta
-        nodejs
         patchPhase
         src;
 
@@ -451,6 +450,9 @@ let
         # This appends the package name and version to the hash string
         # we defined above, so that it is more human-readable.
         export UNIQNAME="''${HASHEDNAME:0:10}-${name}-${version}"
+
+        # Add gyp to the path in case it's needed
+        export PATH=${nodejs}/lib/node_modules/npm/bin/node-gyp-bin:$PATH
       '';
 
       shellHook = ''

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -365,30 +365,8 @@ let
       # Previous NODE_PATH should be empty, but it might have been set
       # in the custom derivation steps.
       "export NODE_PATH=$PWD/node_modules:$NODE_PATH"
-      ''
-      (
-        # NPM reads the `HOME` environment variable and fails if it doesn't
-        # exist, so set it here.
-        export HOME=$PWD
-        echo npm install ${npmFlags}
-
-        # Try doing the install first. If it fails, first check the
-        # dependencies, and if we don't uncover anything there just rerun it
-        # with verbose output.
-        npm install ${npmFlags} >/dev/null 2>&1 || {
-          echo "Installation of ${name}@${version} failed!"
-          echo "Checking dependencies to see if any aren't satisfied..."
-          check-package-json checkDependencies
-          echo "Dependencies seem ok. Rerunning with verbose logging:"
-          npm install . ${npmFlags} --loglevel=verbose
-          if [[ -d node_modules ]]; then
-            echo "node_modules contains these files:"
-            ls -l node_modules
-          fi
-          exit 1
-        }
-      )
-      ''
+      "check-package-json checkDependencies"
+      "execute-install-scripts"
       # If we have any circular dependencies, they will need to reference
       # the current package at runtime. Make a symlink into the node modules
       # folder which points at where the package will live in $out.

--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -125,13 +125,21 @@ let
     #!${pkgs.stdenv.shell}
     exec ${pkgs.python2.interpreter} ${./tools/install-binaries} "$@"
   '';
+
+  # This expression builds the raw C headers and source files for the base
+  # node.js installation. Node packages which use the C API for node need to
+  # link against these files and use the headers.
+  nodejsSources = pkgs.runCommand "node-sources" {} ''
+    tar --no-same-owner --no-same-permissions -xf ${nodejs.src}
+    mv $(find . -type d -mindepth 1 -maxdepth 1) $out
+  '';
 in
 
 rec {
   inherit nodejs;
 
   buildNodePackage = import ./buildNodePackage.nix {
-    inherit pkgs nodejs buildNodePackage xcode-wrapper node-build-tools;
+    inherit pkgs nodejs buildNodePackage xcode-wrapper node-build-tools nodejsSources;
   };
   # A generic package that will fail to build. This is used to indicate
   # packages that are broken, without failing the entire generation of
@@ -203,7 +211,7 @@ rec {
 
       mkScope = scope: ({
         inherit fetchUrlNamespaced fetchUrlWithHeaders namespaceTokens;
-        inherit pkgs buildNodePackage brokenPackage extras;
+        inherit pkgs buildNodePackage brokenPackage extras nodejsSources;
       } // scope);
 
       callPackage = pkgs.newScope (mkScope {
@@ -226,7 +234,7 @@ rec {
       nodePackages = makeExtensible (extends overrides initialNodePackages);
 
     in
-      { inherit callPackage namespaceTokens pkgs node-build-tools;
+      { inherit callPackage namespaceTokens pkgs node-build-tools nodejsSources;
         nodePackages = nodePackages // {inherit nodejs;};
         nodeLib = self args;
       });

--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -93,16 +93,21 @@ let
       fi
     '';
   };
+
   # Directory containing build tools for buildNodePackage
   node-build-tools = pkgs.stdenv.mkDerivation {
     name = "node-build-tools";
-    buildInputs = [pkgs.makeWrapper];
+    buildInputs = [pkgs.makeWrapper nodejs pkgs.python2];
     buildCommand = ''
       mkdir -p $out
       cp -r ${./tools} $out/bin
       chmod -R +w $out/bin
       wrapProgram $out/bin/check-package-json \
         --set SEMVER_PATH ${nodejs}/lib/node_modules/npm/node_modules/semver
+      wrapProgram $out/bin/execute-install-scripts \
+        --prefix PATH : ${dirOf pkgs.python2.interpreter} \
+        --prefix PATH : ${dirOf pkgs.stdenv.shell} \
+        --prefix PATH : ${nodejs}/lib/node_modules/npm/bin/node-gyp-bin
       patchShebangs $out/bin
     '';
   };

--- a/nix-libs/nodeLib/tools/check-package-json
+++ b/nix-libs/nodeLib/tools/check-package-json
@@ -55,32 +55,32 @@ function checkDependencies() {
   var semver = require(process.env.SEMVER_PATH);
   // This will be keyed on the dependency name and version, and valued with
   // the error.
-  var errorsFound = {}
+  var errorsFound = {};
+  var warningsFound = {};
 
   // Given the name and version range of a package, check:
   // * That a package with the given name exists in the node_modules folder.
   // * That its version satisfies the given version bounds.
-  function checkDependency(name, versionRange, dependencyType) {
+  function checkDependency(name, versionRange, errorIfMissing, description) {
     process.stderr.write("  " + name + "@" + versionRange + " -> ");
     var dependencyPackageObj;
     var pkgJsonPath = process.cwd() + "/node_modules/" + name + "/package.json";
     var errorKey = name + "@" + versionRange;
+    function err(message) {
+      var prefix = errorIfMissing ? "ERROR" : "WARNING";
+      message = "(" + description + ") " + message;
+      console.error(prefix + ": " + message);
+      (errorIfMissing ? errorsFound : warningsFound)[errorKey] = message;
+    }
     try {
       dependencyPackageObj = JSON.parse(fs.readFileSync(pkgJsonPath));
     } catch (e) {
-      var message = "Not found in node_modules";
-      // Case: the file didn't exist
-      errorsFound[errorKey] = message;
-      console.error("ERROR: " + message);
-      return
+      return err("Not found in node_modules");
     }
     // Check that the version matches
     var version = dependencyPackageObj.version;
     if (!semver.satisfies(version, versionRange)) {
-      var message = "version " + version + " doesn't match range " + versionRange;
-      errorsFound[errorKey] = message
-      console.error("ERROR: " + message);
-      return
+      return err("version " + version + " doesn't match range " + versionRange);
     }
     console.error("OK (found version " + dependencyPackageObj.version + ")");
 
@@ -88,7 +88,8 @@ function checkDependencies() {
     if (dependencyPackageObj.peerDependencies) {
       console.error("Checking peer dependencies of " + name);
       for (var depName in dependencyPackageObj.peerDependencies) {
-        checkDependency(depName, dependencyPackageObj.peerDependencies[depName]);
+        var range = dependencyPackageObj.peerDependencies[depName];
+        checkDependency(depName, range, false, "peer dependency of " + name);
       }
     };
   }
@@ -102,17 +103,24 @@ function checkDependencies() {
       continue;
     }
     if (packageObj[depType]) {
-      console.log("Checking " + depType);
+      console.log("Checking " + depType + " of " + packageObj.name);
       for (var depName in packageObj[depType]) {
-        checkDependency(depName, packageObj[depType][depName], depType);
+        checkDependency(depName, packageObj[depType][depName], true,
+                        "Appears in " + packageObj.name + "'s " + depType);
       }
     }
   }
 
+  if (JSON.stringify(warningsFound) !== "{}") {
+    console.error("Found the following warnings:");
+    for (var depName in warningsFound) {
+      console.error("  " + depName + ":  " + warningsFound[depName]);
+    }
+  }
   if (JSON.stringify(errorsFound) !== "{}") {
     console.error("Found the following errors:");
     for (var depName in errorsFound) {
-      console.error(depName + ":  " + errorsFound[depName]);
+      console.error("  " + depName + ":  " + errorsFound[depName]);
     }
     fail("One or more dependencies were unsatisfied. :(");
   }

--- a/nix-libs/nodeLib/tools/execute-install-scripts
+++ b/nix-libs/nodeLib/tools/execute-install-scripts
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import json, subprocess, os, sys
+
+# In case a build step references the home directory, set it here.
+if not os.getenv("HOME"):
+   os.environ["HOME"] = os.getcwd()
+
+scripts = json.load(open('package.json')).setdefault("scripts", {})
+for key in ("preinstall", "install", "postinstall"):
+    if scripts.get(key):
+        print("Running {} defined in package.json".format(repr(key)))
+        sys.stdout.flush()
+        proc = subprocess.Popen(["/bin/sh", "-x"], stdin=subprocess.PIPE)
+        proc.communicate(input=scripts[key])
+        if proc.wait() != 0:
+            exit("{} script failed".format(key))

--- a/nix-libs/nodeLib/tools/execute-install-scripts
+++ b/nix-libs/nodeLib/tools/execute-install-scripts
@@ -11,7 +11,7 @@ def runscript(name):
     if scripts.get(name):
         print("Running {} defined in package.json".format(repr(name)))
         sys.stdout.flush()
-        proc = subprocess.Popen(["/bin/sh", "-x"], stdin=subprocess.PIPE)
+        proc = subprocess.Popen(["bash", "-x"], stdin=subprocess.PIPE)
         proc.communicate(input=scripts[name])
         if proc.wait() != 0:
             exit("{} script failed".format(name))
@@ -20,10 +20,8 @@ runscript("preinstall")
 runscript("install")
 
 if os.path.isfile("binding.gyp"):
-   node_gyp = os.path.join(os.environ["nodejs"], "lib", "node_modules",
-                           "npm", "bin", "node-gyp-bin", "node-gyp")
    print("Running node-gyp rebuild due to presence of binding.gyp")
-   if subprocess.call([node_gyp, "rebuild"]) != 0:
+   if subprocess.call(["node-gyp", "rebuild"]) != 0:
       exit("`node-gyp rebuild` failed")
 
 runscript("postinstall")

--- a/nix-libs/nodeLib/tools/execute-install-scripts
+++ b/nix-libs/nodeLib/tools/execute-install-scripts
@@ -5,12 +5,25 @@ import json, subprocess, os, sys
 if not os.getenv("HOME"):
    os.environ["HOME"] = os.getcwd()
 
-scripts = json.load(open('package.json')).setdefault("scripts", {})
-for key in ("preinstall", "install", "postinstall"):
-    if scripts.get(key):
-        print("Running {} defined in package.json".format(repr(key)))
+scripts = json.load(open("package.json")).setdefault("scripts", {})
+
+def runscript(name):
+    if scripts.get(name):
+        print("Running {} defined in package.json".format(repr(name)))
         sys.stdout.flush()
         proc = subprocess.Popen(["/bin/sh", "-x"], stdin=subprocess.PIPE)
-        proc.communicate(input=scripts[key])
+        proc.communicate(input=scripts[name])
         if proc.wait() != 0:
-            exit("{} script failed".format(key))
+            exit("{} script failed".format(name))
+
+runscript("preinstall")
+runscript("install")
+
+if os.path.isfile("binding.gyp"):
+   node_gyp = os.path.join(os.environ["nodejs"], "lib", "node_modules",
+                           "npm", "bin", "node-gyp-bin", "node-gyp")
+   print("Running node-gyp rebuild due to presence of binding.gyp")
+   if subprocess.call([node_gyp, "rebuild"]) != 0:
+      exit("`node-gyp rebuild` failed")
+
+runscript("postinstall")

--- a/nix-libs/nodeLib/tools/execute-install-scripts
+++ b/nix-libs/nodeLib/tools/execute-install-scripts
@@ -21,7 +21,14 @@ runscript("install")
 
 if os.path.isfile("binding.gyp"):
    print("Running node-gyp rebuild due to presence of binding.gyp")
-   if subprocess.call(["node-gyp", "rebuild"]) != 0:
-      exit("`node-gyp rebuild` failed")
+   sys.stdout.flush()
+   if not os.getenv("nodejsSources"):
+      exit("nodejsSources environment variable must be set")
+   cmd = ["node-gyp", "rebuild", "--silly", "--nodedir",
+          os.environ["nodejsSources"]]
+   code = subprocess.call(cmd)
+   if code != 0:
+      print("Command `{}` failed with exit code {}".format(" ".join(cmd), code))
+      exit(code)
 
 runscript("postinstall")

--- a/nixfromnpm.cabal
+++ b/nixfromnpm.cabal
@@ -25,6 +25,7 @@ data-files:   nix-libs/nodeLib/buildNodePackage.nix
             , nix-libs/nodeLib/tools/check-package-json
             , nix-libs/nodeLib/tools/install-binaries
             , nix-libs/nodeLib/tools/patch-dependencies
+            , nix-libs/nodeLib/tools/execute-install-scripts
 
 
 source-repository head


### PR DESCRIPTION
So this is a different solution to the npm woes addressed in #113:

Instead of executing `npm install` or `yarn install`, I just check dependencies and then run a small python script which runs the `preinstall`, `install`, and `postinstall` steps (if defined) as well as executing `node-gyp` if a `binding.gyp` is present. As far as I can tell, this is the only thing that NPM is actually doing, and this way we get control over what happens.

Of course it's not completely without risk to be skipping the community build tool and running the steps ourselves. But it lets us get around a lot of hackery, and also lets me stop raging at npm's failed build output 😛 