### PR TITLE
remove gyp section from execute-install-scripts

### DIFF
--- a/nix-libs/nodeLib/default.nix
+++ b/nix-libs/nodeLib/default.nix
@@ -106,8 +106,7 @@ let
         --set SEMVER_PATH ${nodejs}/lib/node_modules/npm/node_modules/semver
       wrapProgram $out/bin/execute-install-scripts \
         --prefix PATH : ${dirOf pkgs.python2.interpreter} \
-        --prefix PATH : ${dirOf pkgs.stdenv.shell} \
-        --prefix PATH : ${nodejs}/lib/node_modules/npm/bin/node-gyp-bin
+        --prefix PATH : ${dirOf pkgs.stdenv.shell}
       patchShebangs $out/bin
     '';
   };

--- a/nix-libs/nodeLib/tools/execute-install-scripts
+++ b/nix-libs/nodeLib/tools/execute-install-scripts
@@ -18,17 +18,4 @@ def runscript(name):
 
 runscript("preinstall")
 runscript("install")
-
-if os.path.isfile("binding.gyp"):
-   print("Running node-gyp rebuild due to presence of binding.gyp")
-   sys.stdout.flush()
-   if not os.getenv("nodejsSources"):
-      exit("nodejsSources environment variable must be set")
-   cmd = ["node-gyp", "rebuild", "--silly", "--nodedir",
-          os.environ["nodejsSources"]]
-   code = subprocess.call(cmd)
-   if code != 0:
-      print("Command `{}` failed with exit code {}".format(" ".join(cmd), code))
-      exit(code)
-
 runscript("postinstall")


### PR DESCRIPTION
This fixes #122. I'm not totally sure if it's the right decision across the board, but I think it may be. Basically I was apparently mistaken in believing that we needed to hard-code the evocation of `node-gyp rebuild` in the presence of a `bindings.gyp` file. Apparently packages which use `gyp` are supposed to include an `install` script which runs this, or in the case of fsevents, run a different command instead, which is what the problem was.

It's also possible that npm *does* do some kind of automatic running of gyp, but that should be overridden by an `install` section in the `package.json` file. We still need a few test cases to answer this question I suppose.