### PR TITLE
use tryEval on elements of optionalDependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,3 +58,11 @@ jobs:
             cd $(mktemp -d)
             nixfromnpm -o output -f "$PACKAGE_DIR"
             nix-build $PACKAGE_DIR --max-jobs 2
+
+      - run:
+          name: Build package with an optional dependency (that will fail on linux)
+          command: |
+            PATH=$(readlink result)/bin:$PATH
+            cd $(mktemp -d)
+            nixfromnpm -o output -p 'sane@2.5.0'
+            nix-build output -A nodePackages.sane_2-5-0 --max-jobs 2

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -215,8 +215,13 @@ let
     _dependencies = toAttrSet deps;
     # Set of circular dependencies.
     _circularDependencies = toAttrSet circularDependencies;
-    # Set of optional dependencies.
-    _optionalDependencies = toAttrSet optionalDependencies;
+
+    # Since optional dependencies are optional, ignore the ones that fail
+    _optionalDependencies = mapAttrs (_: result: result.value) (
+        filterAttrs (_: result: result.success) (
+          mapAttrs (_: builtins.tryEval) (toAttrSet optionalDependencies)
+        )
+      );
 
     # Dev dependencies will only be included if requested.
     _devDependencies = if !includeDevDependencies then {}

--- a/src/NixFromNpm/Npm/Types.hs
+++ b/src/NixFromNpm/Npm/Types.hs
@@ -234,11 +234,14 @@ instance FromJSON VersionInfo where
     version <- o .: "version"
     packageMeta <- parseJSON (Object o)
     scripts :: Record Value <- getDict "scripts" o <|> fail "couldn't get scripts"
+    -- Remove any keys which appear in `optionalDependencies` from
+    -- the dependencies and devdependencies sets.
+    let rmOptionals = flip H.difference optionalDependencies
     case parseSemVer version of
       Left _ -> throw $ VersionSyntaxError version
       Right semver -> return $ VersionInfo {
-        viDependencies = dependencies,
-        viDevDependencies = devDependencies,
+        viDependencies = rmOptionals dependencies,
+        viDevDependencies = rmOptionals devDependencies,
         viOptionalDependencies = optionalDependencies,
         viBundledDependencies = bundledDependencies,
         viDist = dist,


### PR DESCRIPTION
Because of #125, nix will refuse to evaluate definitions of packages like `sane` on linux which depend on a package (`fsevents`) which isn't supported on the given platform. However, in this case they *should* still build because the package is listed as an *optional* dependency. Use `tryEval` to achieve this behavior.