### PR TITLE
buildNodePackage: always make the module path directory before symlinking

### DIFF
--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -294,8 +294,8 @@ let
     let
       # Symlink dependencies for node modules.
       link = dep: ''
+        mkdir -p ${dep.modulePath}
         if ! [[ -e node_modules/${dep.fullName} ]]; then
-          mkdir -p ${dep.modulePath}
           ln -sv ${dep.fullPath} ${dep.modulePath}
           if [[ -d ${dep}/bin ]]; then
             find -L ${dep}/bin -maxdepth 1 -type f -executable \

--- a/nix-libs/nodeLib/buildNodePackage.nix
+++ b/nix-libs/nodeLib/buildNodePackage.nix
@@ -295,6 +295,7 @@ let
       # Symlink dependencies for node modules.
       link = dep: ''
         if ! [[ -e node_modules/${dep.fullName} ]]; then
+          mkdir -p ${dep.modulePath}
           ln -sv ${dep.fullPath} ${dep.modulePath}
           if [[ -d ${dep}/bin ]]; then
             find -L ${dep}/bin -maxdepth 1 -type f -executable \
@@ -308,12 +309,7 @@ let
       '';
     in concatStringsSep "\n" (
       ["runHook preConfigure"] ++
-      (flip map (attrValues requiredDependencies) (dep:
-        # Create symlinks (or copies) of all of the required dependencies.
-        ''
-          mkdir -p ${dep.modulePath}
-          ${link dep}
-        '')) ++
+      (flip map (attrValues requiredDependencies) link) ++
       ["runHook postConfigure"] ++
       (optional (circulars != []) (let
        in concatStringsSep "\n" [


### PR DESCRIPTION
This change fixes a problem that can occur when creating the symlinks for the circular dependencies of a package that uses a namespaced package path.

Since we always called `mkdir -p ${dep.modulePath}` for required dependencies before creating symlinks, we should do the same when creating symlinks for circular dependencies.